### PR TITLE
Support legacy-telepresence and telepresence2 via brew

### DIFF
--- a/Formula/telepresence-legacy.rb
+++ b/Formula/telepresence-legacy.rb
@@ -1,6 +1,6 @@
 # This script is generated automatically by the release automation code in the
 # Telepresence repository:
-class Telepresence < Formula
+class TelepresenceLegacy < Formula
   include Language::Python::Virtualenv
   desc "Local dev environment attached to a remote Kubernetes cluster"
   homepage "https://telepresence.io"

--- a/Formula/telepresence2.rb
+++ b/Formula/telepresence2.rb
@@ -1,0 +1,21 @@
+# This script is generated automatically by the release automation code in the
+# Telepresence repository:
+class Telepresence2 < Formula
+  desc "Local dev environment attached to a remote Kubernetes cluster"
+  homepage "https://telepresence.io"
+  url "https://app.getambassador.io/download/tel2/darwin/amd64/2.2.2/telepresence"
+  sha256 "966e32c24fab7ac83c033115eeca583e2360e0d0e88683f05c46d25738349192"
+
+  # macfuse is a cask and formula can't depend on casks, so we can't actually
+  # do this. This is probably fine since you don't _need_ macfuse to run
+  # the cli, just to do mounts 
+  #depends_on "macfuse"
+
+  def install
+    bin.install "telepresence"
+  end
+
+  test do
+    system "#{bin}/telepresence", "--help"
+  end
+end

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -1,0 +1,3 @@
+{
+    "telepresence": "telepresence-legacy"
+}


### PR DESCRIPTION
Purpose: Make it so you can `brew install datawire/blackbird/telepresence` (technically `brew install datawire/blackbird/telepresence-legacy`) and `brew install datawire/blackbird/telepresence2`

Our CI will update the telepresence2 formula for new versions and in a future PR (once we move the docs over), we will have legacy Telepresence installable only via `brew install datawire/blackbird/telepresence-legacy` and the new Telepresence installable via `brew install datawire/blackbird/telepresence`

Added Luke and Thomas as reviewers, but only need one, so whoever gets to it first :) 