### PR TITLE
switch telepresense-legacy to "gromgit/fuse/sshfs-mac"

### DIFF
--- a/Formula/telepresence-legacy.rb
+++ b/Formula/telepresence-legacy.rb
@@ -9,7 +9,7 @@ class TelepresenceLegacy < Formula
 
   depends_on "python"
   depends_on "torsocks"
-  depends_on "sshfs"
+  depends_on "gromgit/fuse/sshfs-mac"
 
   def install
     bin.install "bin/telepresence"


### PR DESCRIPTION
Hi, as sshfs is removed from homebrew core, and instead moved to "gromgit/fuse/sshfs-mac", let's switch to it ? I have tested and this works absolutely fine
ref: https://github.com/Homebrew/homebrew-core/issues/75656