### PR TITLE
Make Telepresence 2 the default

### DIFF
--- a/Formula/telepresence.rb
+++ b/Formula/telepresence.rb
@@ -1,6 +1,6 @@
 # This script is generated automatically by the release automation code in the
 # Telepresence repository:
-class Telepresence2 < Formula
+class Telepresence < Formula
   desc "Local dev environment attached to a remote Kubernetes cluster"
   homepage "https://telepresence.io"
   url "https://app.getambassador.io/download/tel2/darwin/amd64/2.3.1/telepresence"

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -1,3 +1,3 @@
 {
-    "telepresence": "telepresence-legacy"
+    "telepresence2": "telepresence"
 }


### PR DESCRIPTION
Now that we've switched over telepresence.io to default to Telepresence (Telepresence 2), let's update brew to install Telepresence 2 when users use `brew install datawire/blackbird/telepresence`. 

`brew install datawire/blackbird/telepresence-legacy` will still get you legacy Telepresence)