### PR TITLE
Revert 2nd switch to 2.3.4

### DIFF
--- a/Formula/telepresence.rb
+++ b/Formula/telepresence.rb
@@ -4,7 +4,7 @@ class Telepresence < Formula
   desc "Local dev environment attached to a remote Kubernetes cluster"
   homepage "https://telepresence.io"
   url "https://app.getambassador.io/download/tel2/darwin/amd64/2.3.4/telepresence"
-  sha256 "843b8bd6c31e82352b25de6a063781fe05b3a3173ba5fb6c0377772eed3b3fa1"
+  sha256 "774daf6aedc26efd7605a22324bd80e12e5133624448ee8eb5258d869306fd6e"
 
   # macfuse is a cask and formula can't depend on casks, so we can't actually
   # do this. This is probably fine since you don't _need_ macfuse to run


### PR DESCRIPTION
This reverts commit fc00471f8a6481d29096f3d57d05562a2ad94a18.

Ran into this when re-running `make promote-to-stable`: 
```
==> Downloading https://app.getambassador.io/download/tel2/darwin/amd64/2.3.4/telepresence
Already downloaded: /Users/donaldyung/Library/Caches/Homebrew/downloads/488e1a3aa24a1e374d8f85906d7c6524552b6926bfb5e7a3699c50738e219d87--telepresence
Error: SHA256 mismatch
Expected: 843b8bd6c31e82352b25de6a063781fe05b3a3173ba5fb6c0377772eed3b3fa1
  Actual: 774daf6aedc26efd7605a22324bd80e12e5133624448ee8eb5258d869306fd6e
    File: /Users/donaldyung/Library/Caches/Homebrew/downloads/488e1a3aa24a1e374d8f85906d7c6524552b6926bfb5e7a3699c50738e219d87--telepresence
```
 We should fix that script so it can be re-run but in the meantime...